### PR TITLE
Notebook 01 mse2023 feeback

### DIFF
--- a/01-Atomic_scale_structures.ipynb
+++ b/01-Atomic_scale_structures.ipynb
@@ -408,7 +408,8 @@
     "    assert isinstance(output, ase.Atoms), f\"TypeAssert failed: Expected type ase.Atoms but got {type(output)}.\"\n",
     "    assert len(output) == 1, f\"LenAssert failed: Expected length 1 but got {len(output)}.\"\n",
     "    assert np.sum(84 == output.numbers) == 1, f\"One Polonium is expected in the molecule. Found {np.sum(84 == output.numbers)} Polonium atom(s).\"\n",
-    "    assert np.allclose(output.cell,3.3596173*np.eye(3)), f\"Unit cell has wrong dimensions.\"\n",
+    "    assert output.cell.shape == (3,3), f\"Unit cell has wrong dimensions.\"\n",
+    "    assert np.allclose(output.cell, 3.3596173*np.eye(3), atol=1e-5,) f\"Unit cell is not correct or not accurate enough.\"\n",
     "    return fingerprint_ase_atoms(output)\n",
     " \n",
     "    \n",
@@ -439,10 +440,16 @@
    "source": [
     "Periodic boundary conditions are not only used to model perfect crystals. They are also used as a practical way to describe bulk systems, while using a finite number of atomic degrees of freedom: the size of the cell and the coordinates of the atoms in a single repeate unit. Compare these two systems:\n",
     "\n",
-    "a) a finite-sized droplet with 10 water molecules\n",
-    "<img src=\"figures/pbc-1.png\" width=\"400\"/>\n",
-    "b) a periodic system with a repeat unit of 10 water molecules\n",
-    "<img src=\"figures/pbc-2.png\" width=\"400\"/>"
+    "<table style=\"width:100%\">\n",
+    "  <tr>\n",
+    "    <th>a) a finite-sized droplet with 10 water molecules</th>\n",
+    "    <th>b) a periodic system with a repeat unit of 10 water molecules</th>\n",
+    "  </tr>\n",
+    "  <tr>\n",
+    "    <th><img src=\"figures/pbc-1.png\" width=\"400\"/></th>\n",
+    "    <th><img src=\"figures/pbc-2.png\" width=\"400\"/></th>\n",
+    "  </tr>\n",
+    "</table>"
    ]
   },
   {


### PR DESCRIPTION
https://github.com/lab-cosmo/chemiscope/issues/269#issuecomment-1448192499Fixed in this PR
* adapt error message of ex 3 saying wrong unit cell
* improving in-notebook formatting for pbc-1.png and pbc-2.png

Open bugs
* error messages in widget code input are not correctly shown to student, I think this is because widget code input fixed this in version 3.5.0, but we are using 3.0.0 because it the new version caused bugs, and in scicode-wigdets we removed it already. So I think we should temporary put it back here. Would fix this in a different PR
* unit cell is not shown in chemiscope for some people on noto, chemiscope version is the same (0.5.1) and ase (3.22.1), pbc is True, cell is the same, discussed in  https://github.com/lab-cosmo/chemiscope/issues/269#issuecomment-1448192499